### PR TITLE
SONARFLEX-76 NPE in rule (S1172) Unused function parameters

### DIFF
--- a/flex-checks/src/main/java/org/sonar/flex/checks/UnusedFunctionParametersCheck.java
+++ b/flex-checks/src/main/java/org/sonar/flex/checks/UnusedFunctionParametersCheck.java
@@ -207,11 +207,17 @@ public class UnusedFunctionParametersCheck extends SquidCheck<LexerlessGrammar> 
         .getFirstChild(FlexGrammar.FUNCTION_SIGNATURE)
         .getFirstChild(FlexGrammar.PARAMETERS);
       if (parameters != null) {
-        AstNode firstParameterType = parameters
-          .getFirstChild(FlexGrammar.PARAMETER)
-          .getFirstChild(FlexGrammar.TYPED_IDENTIFIER)
-          .getFirstChild(FlexGrammar.TYPE_EXPR);
-        return firstParameterType.getLastToken().getValue().endsWith("Event");
+        AstNode firstParameter = parameters.getFirstChild(FlexGrammar.PARAMETER);
+        if (firstParameter != null) {
+          if (firstParameter.getFirstChild(FlexGrammar.TYPED_IDENTIFIER) != null) {
+            AstNode firstParameterType = firstParameter
+              .getFirstChild(FlexGrammar.TYPED_IDENTIFIER)
+              .getFirstChild(FlexGrammar.TYPE_EXPR);
+            if (firstParameterType != null) {
+              return firstParameterType.getLastToken().getValue().endsWith("Event");
+            }
+          }
+        }
       }
     }
     return false;

--- a/flex-checks/src/test/java/org/sonar/flex/checks/UnusedFunctionParametersCheckTest.java
+++ b/flex-checks/src/test/java/org/sonar/flex/checks/UnusedFunctionParametersCheckTest.java
@@ -43,6 +43,8 @@ public class UnusedFunctionParametersCheckTest {
       .next().atLine(64).withMessage("Remove the unused function parameter \"e\".")
       .next().atLine(65).withMessage("Remove the unused function parameter \"e\".")
       .next().atLine(74).withMessage("Remove the unused function parameter \"e\".")
+      .next().atLine(77).withMessage("Remove the unused function parameter \"args\".")
+      .next().atLine(78).withMessage("Remove the unused function parameter \"args\".")
       .noMore();
   }
 

--- a/flex-checks/src/test/resources/checks/UnusedFunctionParameters.as
+++ b/flex-checks/src/test/resources/checks/UnusedFunctionParameters.as
@@ -73,3 +73,6 @@ function onSomething()              { return; } // OK
 
 function onlySomething(e:MouseEvent) { return; } // NOK
 function on(e:MouseEvent) { return; } // OK
+
+function restSomething(...args) { return; } // NOK
+function onRestSomething(...args) { return; } // NOK


### PR DESCRIPTION
Fix NullPointerException in UnusedFunctionParameters rule. 
Happened when (rest) parameters were being used.